### PR TITLE
feat: Tags passed into worker_groups_launch_template extend var.tags for the volumes 

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -30,7 +30,7 @@ locals {
   policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   workers_group_defaults_defaults = {
     name                          = "count.index"               # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
-    tags                          = []                          # A list of map defining extra tags to be applied to the worker group autoscaling group.
+    tags                          = []                          # A list of maps defining extra tags to be applied to the worker group autoscaling group and volumes.
     ami_id                        = ""                          # AMI ID for the eks linux based workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI based on platform.
     ami_id_windows                = ""                          # AMI ID for the eks windows based workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI based on platform.
     asg_desired_capacity          = "1"                         # Desired worker capacity in the autoscaling group and changing its value will not affect the autoscaling group's desired capacity because the cluster-autoscaler manages up and down scaling of the nodes. Cluster-autoscaler add nodes when pods are in pending state and remove the nodes when they are not required by modifying the desirec_capacity of the autoscaling group. Although an issue exists in which if the value of the asg_min_size is changed it modifies the value of asg_desired_capacity.

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -530,6 +530,10 @@ resource "aws_launch_template" "workers_launch_template" {
         )}-eks_asg"
       },
       var.tags,
+      {
+        for tag in lookup(var.worker_groups_launch_template[count.index], "tags", local.workers_group_defaults["tags"]) :
+        tag["key"] => tag["value"]
+      }
     )
   }
 


### PR DESCRIPTION
This change brings an option to extend `var.tags` for the EBS volumes with tags that are passed into `var.worker_groups_launch_template` or `var.workers_group_defaults`.

This resolves #1396.

The main use case for this to separate resources costs between owners for shared cluster usage.

Since tagging of EC2 instances via `var.worker_groups_launch_template` or `var.workers_group_defaults` is already done, I assume it should be useful to tag volumes as well.

As a result of this change, tags from `var.worker_groups_launch_template` will override tags in `var.workers_group_defaults` if any and then will be merged with `var.tags` for EBS volumes of ASG created via launch templates.



### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
