### PR TITLE
Add client_id_list input variable to define audiences for OIDC provider

### DIFF
--- a/irsa.tf
+++ b/irsa.tf
@@ -9,7 +9,7 @@
 
 resource "aws_iam_openid_connect_provider" "oidc_provider" {
   count           = var.enable_irsa && var.create_eks ? 1 : 0
-  client_id_list  = [local.sts_principal]
+  client_id_list  = local.client_id_list
   thumbprint_list = [var.eks_oidc_root_ca_thumbprint]
   url             = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
 

--- a/local.tf
+++ b/local.tf
@@ -27,6 +27,8 @@ locals {
   ec2_principal = "ec2.${data.aws_partition.current.dns_suffix}"
   sts_principal = "sts.${data.aws_partition.current.dns_suffix}"
 
+  client_id_list = distinct(compact(concat([local.sts_principal], var.client_id_list)))
+
   policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   workers_group_defaults_defaults = {
     name                              = "count.index"               # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.

--- a/variables.tf
+++ b/variables.tf
@@ -337,6 +337,12 @@ variable "enable_irsa" {
   default     = false
 }
 
+variable "client_id_list" {
+  description = "A list of client IDs (also known as audiences) to extend Global region endpoint. This is the value that's sent as the client_id parameter on OAuth requests."
+  type        = list(any)
+  default     = []
+}
+
 variable "eks_oidc_root_ca_thumbprint" {
   type        = string
   description = "Thumbprint of Root CA for EKS OIDC, Valid until 2037"


### PR DESCRIPTION
Add `client_id_list` input variable to extend default value of the `client_id_list` for `aws_iam_openid_connect_provider`.

By default, `client_id_list = ["sts.${data.aws_partition.current.dns_suffix}"]` which is Global Region endpoint.
If `var.client_id_list` is set, then   `client_id_list = distinct(compact(concat(["sts.${data.aws_partition.current.dns_suffix}"], var.client_id_list)))`

